### PR TITLE
Fix Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-export default defineConfig({
+const repoName = "meticulos-power-profile";
+
+export default defineConfig(({ mode }) => ({
   plugins: [vue()],
-  base: "/",
-});
+  base: mode === "production" ? `/${repoName}/` : "/",
+}));


### PR DESCRIPTION
## Summary
- configure Vite to use the repository path as the base when building for production
- keep development builds using the root base path for local development compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9594a93ac832faccf1215749e6138