### PR TITLE
Align interpolation and max pressure controls inline

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,25 +44,25 @@
         Drag a point to adjust, or click a point to edit its values directly.<br>
         Double-click to add a point. Right-click a point to remove it.<br>
       </div>
-      <div class="mb-2 flex flex-col items-center">
-        <label class="font-semibold mb-1" for="interpolation-input">Interpolation (stages between points):</label>
+      <div class="mb-2 flex items-center justify-center gap-2">
+        <label class="font-semibold" for="interpolation-input">Interpolation (stages between points):</label>
         <input
           id="interpolation-input"
           type="number"
           min="1"
           v-model.number="interpolation"
-          class="border px-2 py-1 w-24 rounded text-center"
+          class="border px-2 py-1 w-16 rounded text-center"
         />
       </div>
-      <div class="mb-4 flex flex-col items-center">
-        <label class="font-semibold mb-1" for="max-pressure-input">Max pressure limit (bar):</label>
+      <div class="mb-4 flex items-center justify-center gap-2">
+        <label class="font-semibold" for="max-pressure-input">Max pressure limit (bar):</label>
         <input
           id="max-pressure-input"
           type="number"
           min="0"
           step="0.1"
           v-model.number="maxPressure"
-          class="border px-2 py-1 w-24 rounded text-center"
+          class="border px-2 py-1 w-16 rounded text-center"
         />
       </div>
       <div v-if="jsonOutput" class="mt-4">


### PR DESCRIPTION
## Summary
- place the interpolation and max pressure inputs on the same line as their labels
- shrink the number input widths so they only accommodate the two-digit values and spinner

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d962783a48832f81cb727c07ce8f7f